### PR TITLE
状态命令图片优化

### DIFF
--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -191,7 +191,7 @@ def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", backgroun
             this_height += 29
             this_width = 29
             background.alpha_composite(this_chip, (this_width, this_height))
-            this_width += this_chip.width
+            this_width += this_chip.width + 5
 
     result_image = background.generate(color=background_color, padding=(10, 10, 10, 10), override_size=(CHIPS_LIST_WIDTH, max(background.height, 64)))  # 限制最小大小
     result_image.alpha_composite(text_image, (5, center(result_image, text_image)[1]))  # 需要在 BackGroundGenerator 生成之后，否则可能会被 override_size 强制指定大小后获得错误坐标

--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -158,7 +158,7 @@ def user_chips(head_icon: Image.Image, user_name: str) -> Image.Image:
 
 def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", background_color: Tuple[int, int, int] = (255, 255, 255)) -> Image.Image:
     global glovar_missing_user_id
-    OVERALL_CHIPS_LIST_WITH = 414
+    OVERALL_CHIPS_LIST_WITH = 414 - 20
     CHIPS_LIST_WIDTH = OVERALL_CHIPS_LIST_WITH - 29
     CHIPS_INTERVAL = 5
     background = BackGroundGenerator()
@@ -166,7 +166,7 @@ def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", backgroun
     is_white_text = True if ((background_color[0] * 0.299 + background_color[1] * 0.587 + background_color[2] * 0.114) / 255) < 0.5 else False
     text_image = get_font_image("\n".join([i for i in text]), 24, (255, 255, 255) if is_white_text else (0, 0, 0))
     if not chips_array:
-        background = Image.new("RGBA", (OVERALL_CHIPS_LIST_WITH, 64), background_color)
+        background = Image.new("RGBA", (OVERALL_CHIPS_LIST_WITH + 20, 70), background_color)
         background.alpha_composite(text_image, (5, center(background, text_image)[1]))
         text_image = get_font_image(f"暂无{text}", 28, (255, 255, 255) if is_white_text else (0, 0, 0))
         background.alpha_composite(text_image, center(background, text_image))
@@ -239,14 +239,18 @@ def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", backgroun
 
 
 def get_process_image(finish_challenge_count: int, half_challenge_list: Dict[str, str]):
-    overall_image = Image.new("RGBA", (498, 500), (255, 255, 255, 0))
+    overall_image = BackGroundGenerator()
+
+    full_challenge_background = BackGroundGenerator()
     full_challenge_text = get_font_image(f"完整刀", 24)
     full_challenge_count_text = get_font_image(str(finish_challenge_count), 24, (255, 0, 0))
-    overall_image.alpha_composite(full_challenge_text, (round((148 - full_challenge_text.width) / 2), 15))
-    overall_image.alpha_composite(full_challenge_count_text, (round((148 - full_challenge_count_text.width) / 2), 49))
+    full_challenge_background.alpha_composite(full_challenge_text, (0, 0))
+    full_challenge_background.alpha_composite(full_challenge_count_text, (full_challenge_background.center(full_challenge_count_text)[0], 34))
+
     chips_list_image = chips_list(half_challenge_list, "补偿", (237, 231, 246))
-    overall_image.alpha_composite(chips_list_image, (148, 10))
-    return overall_image.crop((0, 0, 498, chips_list_image.height + 20))
+    overall_image.alpha_composite(chips_list_image, (0, 78))
+    overall_image.alpha_composite(round_corner(full_challenge_background.generate(color=(255, 205, 210), padding=(10, 10, 10, 10)), 5), (0, 0))
+    return overall_image.generate(padding=(10, 20, 10, 20))
 
 
 class BossStatusImageCore:
@@ -333,7 +337,7 @@ class BossStatusImageCore:
             background.alpha_composite(chips_list_image, (0, current_chips_height))
             current_chips_height += chips_list_image.height + 10
 
-        return background.generate()
+        return background.generate(color=background_color, padding=(10, 20, 10, 20))
 
 
 def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], before: Optional[Image.Image] = None, after: Optional[Image.Image] = None) -> Image.Image:
@@ -354,7 +358,6 @@ def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], bef
 
     if after:
         background.paste(after, (0, current_y_cursor))
-
 
     return background.generate()
 

--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -208,6 +208,8 @@ def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", backgroun
                     # 因为是从短到长  先找出这一行里面第二个能放下最长的chip
                     last_loop_result = this_short_chips_address
                     continue
+                if this_short_chips_address == 0 and (current_width + chips_image_list[this_short_chips_address].width < CHIPS_LIST_WIDTH):
+                    last_loop_result = 0
                 # 在这一行添加这个chip  与上面添加长chip的操作一样
                 this_sort_chip_image = chips_image_list[last_loop_result]
                 chips_image_list.pop(last_loop_result)

--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -158,7 +158,7 @@ def user_chips(head_icon: Image.Image, user_name: str) -> Image.Image:
 
 def chips_list(chips_array: Dict[str, str] = {}, text: str = "内容", background_color: Tuple[int, int, int] = (255, 255, 255)) -> Image.Image:
     global glovar_missing_user_id
-    OVERALL_CHIPS_LIST_WITH = 320
+    OVERALL_CHIPS_LIST_WITH = 414
     CHIPS_LIST_WIDTH = OVERALL_CHIPS_LIST_WITH - 29
     CHIPS_INTERVAL = 5
     background = BackGroundGenerator()
@@ -269,7 +269,7 @@ class BossStatusImageCore:
         self.extra_chips_array = extra_chips_array
 
     def hp_percent_image(self) -> Image.Image:
-        HP_PERCENT_IMAGE_SIZE = (340, 24)
+        HP_PERCENT_IMAGE_SIZE = (340, 30)
         background = Image.new("RGBA", HP_PERCENT_IMAGE_SIZE, (200, 200, 200))
         background_draw = ImageDraw.Draw(background, "RGBA")
         percent_pixel_cursor_x = round(self.current_hp / self.max_hp * HP_PERCENT_IMAGE_SIZE[0])
@@ -306,31 +306,31 @@ class BossStatusImageCore:
         return round_corner(background)
 
     def generate(self, background_color: Tuple[int, int, int] = (255, 255, 255)) -> Image.Image:
-        BOSS_HEADER_SIZE = 128
+        BOSS_HEADER_SIZE = 64
 
         background = BackGroundGenerator()
 
         boss_name_image = get_font_image(self.name, 24)
-        background.alpha_composite(boss_name_image, (BOSS_HEADER_SIZE + 20, 10))
-        background.alpha_composite(self.cyle_round_image(), (BOSS_HEADER_SIZE + 30 + boss_name_image.width, 10))
-        background.alpha_composite(self.hp_percent_image(), (BOSS_HEADER_SIZE + 20, 44))
+        background.alpha_composite(boss_name_image, (BOSS_HEADER_SIZE + 10, 0))
+        background.alpha_composite(self.cyle_round_image(), (BOSS_HEADER_SIZE + 20 + boss_name_image.width, 0))
+        background.alpha_composite(self.hp_percent_image(), (BOSS_HEADER_SIZE + 10, 34))
 
         if not BOSS_ICON_PATH.joinpath(self.boss_icon_id + ".webp").is_file():
             boss_icon = Image.new("RGBA", (128, 128), (255, 255, 255, 0))
         else:
             boss_icon = Image.open(BOSS_ICON_PATH.joinpath(self.boss_icon_id + ".webp"), "r")
 
-        boss_icon = boss_icon.resize((128, 128))
+        boss_icon = boss_icon.resize((BOSS_HEADER_SIZE, BOSS_HEADER_SIZE))
         boss_icon = round_corner(boss_icon, 10)
-        background.alpha_composite(boss_icon, (10, 10))
+        background.alpha_composite(boss_icon, (0, 0))
 
-        current_chips_height = 78
+        current_chips_height = 74
         for this_chips_list in self.extra_chips_array:
             chips_background_color = (240, 240, 240)
             if this_chips_list in CHIPS_COLOR_DICT:
                 chips_background_color = CHIPS_COLOR_DICT[this_chips_list]
             chips_list_image = chips_list(self.extra_chips_array[this_chips_list], this_chips_list, chips_background_color)
-            background.alpha_composite(chips_list_image, (BOSS_HEADER_SIZE + 20, current_chips_height))
+            background.alpha_composite(chips_list_image, (0, current_chips_height))
             current_chips_height += chips_list_image.height + 10
 
         return background.generate()
@@ -354,7 +354,7 @@ def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], bef
 
     if after:
         background.paste(after, (0, current_y_cursor))
-        
+
 
     return background.generate()
 

--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -343,7 +343,7 @@ def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], bef
 
     if before:
         background.paste(before, (0, 0))
-        current_y_cursor = before.height
+        current_y_cursor += before.height
         format_color_flag = True
 
     for this_image in boss_state:
@@ -354,9 +354,9 @@ def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], bef
 
     if after:
         background.paste(after, (0, current_y_cursor))
-        current_y_cursor += after.height
+        
 
-    return background.generate().crop((0, 0, background.width, current_y_cursor))
+    return background.generate()
 
 
 async def download_pic(url: str, proxies: Optional[str] = None, file_name="") -> Optional[Path]:

--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -308,7 +308,7 @@ class BossStatusImageCore:
     def generate(self, background_color: Tuple[int, int, int] = (255, 255, 255)) -> Image.Image:
         BOSS_HEADER_SIZE = 128
 
-        background = Image.new("RGBA", (498, 1000), background_color)
+        background = BackGroundGenerator()
 
         boss_name_image = get_font_image(self.name, 24)
         background.alpha_composite(boss_name_image, (BOSS_HEADER_SIZE + 20, 10))
@@ -333,7 +333,7 @@ class BossStatusImageCore:
             background.alpha_composite(chips_list_image, (BOSS_HEADER_SIZE + 20, current_chips_height))
             current_chips_height += chips_list_image.height + 10
 
-        return background.crop((0, 0, background.width, current_chips_height))
+        return background.generate()
 
 
 def generate_combind_boss_state_image(boss_state: List[BossStatusImageCore], before: Optional[Image.Image] = None, after: Optional[Image.Image] = None) -> Image.Image:


### PR DESCRIPTION
状态命令图片优化 #40 
- 使用新的用户chips排序算法，排序空间利用率更高
- 使用自写的背景生成器类替代了Image.new().crop()方法，被动生成画布，占用更低且可以生成无限长度的图片了
- 修复了一些自动排版时可能导致的问题
- 重新调了一下图片样式

**当前样式预览：**
![1652331953c8cd30](https://user-images.githubusercontent.com/44545625/230735599-3fc4bb18-4234-445e-b3d1-2bf729ed9906.jpg)
