### PR TITLE
修改状态图

### DIFF
--- a/src/client/ybplugins/clan_battle/components/image_engine.py
+++ b/src/client/ybplugins/clan_battle/components/image_engine.py
@@ -407,6 +407,7 @@ class BossStatusImageCore:
         name: str,
         boss_icon_id: str,
         extra_chips_array: Dict[str, Dict[str, Any]],
+        is_next: bool,
     ) -> None:
         self.current_hp = current_hp
         self.max_hp = max_hp
@@ -414,6 +415,7 @@ class BossStatusImageCore:
         self.name = name
         self.boss_icon_id = boss_icon_id
         self.extra_chips_array = extra_chips_array
+        self.is_next = is_next
 
     def hp_percent_image(self) -> Image.Image:
         HP_PERCENT_IMAGE_SIZE = (315, 24)
@@ -453,7 +455,8 @@ class BossStatusImageCore:
 
         text_str = f"{self.round} 周目"
         text_image = get_font_image(text_str, CYCLE_TEXT_SIZE, (255, 255, 255))
-        background = Image.new("RGBA", (text_image.width + CYCLE_IMAGE_HEIGHT, CYCLE_IMAGE_HEIGHT), (3, 169, 244, 255))  # 已确保关闭
+        color_code = (106, 152, 243, 255) if self.is_next else (228, 94, 104, 255)
+        background = Image.new("RGBA", (text_image.width + CYCLE_IMAGE_HEIGHT, CYCLE_IMAGE_HEIGHT), color_code)  # 已确保关闭
         background.alpha_composite(text_image, center(background, text_image))
         return round_corner(background)
 

--- a/src/client/ybplugins/clan_battle/components/realize.py
+++ b/src/client/ybplugins/clan_battle/components/realize.py
@@ -1328,10 +1328,12 @@ def challenger_info(self, group_id):
 			this_boss_data['cycle'], 
 			this_boss_data["health"],
 			this_boss_data["full_health"],
-			this_boss_data["name"],
+			boss_num_str + '-' + this_boss_data["name"],
 			this_boss_data["icon_id"],
-			extra_info
+			extra_info,
+			this_boss_data['is_next']
 		))
+	level_cycle = self._level_by_cycle(group.boss_cycle, group.game_server)
 	process_image = get_process_image(
 		[
 			GroupStateBlock(
@@ -1343,10 +1345,10 @@ def challenger_info(self, group_id):
 			),
 			GroupStateBlock(
 				title_text="阶段",
-				data_text=chr(65+self._level_by_cycle(group.boss_cycle, group.game_server)),
+				data_text=chr(65+level_cycle),
 				title_color=(255, 255, 255),
 				data_color=(255, 255, 255),
-				background_color=(3, 169, 244),
+				background_color=[(132, 1, 244), (115, 166, 231), (206, 105, 165), (206, 80, 66), (181, 105, 206)][level_cycle],
 			),
 		],
 		{"补偿": half_challenge_list}


### PR DESCRIPTION
主要是修改了一些地方的颜色
左上角大阶段的背景色改为了和游戏内一致
boss小图的周目数背景色改为当前周目为红色，下一周目蓝色，也是和游戏内一样
然后给boss名称前面加了个序号看的方便点
rt
![QQ图片20230422133756](https://user-images.githubusercontent.com/75929887/233765034-15cac59b-45e9-4856-98d1-393623f9dbca.jpg)
