### PR TITLE
Try to fix compatibility with Quart 0.19 and Flask 3.0

### DIFF
--- a/src/client/ybplugins/homepage.py
+++ b/src/client/ybplugins/homepage.py
@@ -16,7 +16,7 @@ class Index:
 
     def register_routes(self, app: Quart):
 
-        @app.route(self.public_basepath, ["GET"])
+        @app.route(self.public_basepath, methods=["GET"])
         async def yobot_homepage():
             return await render_template(
                 "homepage.html",
@@ -35,7 +35,7 @@ class Index:
                 verinfo=self.setting["verinfo"]["ver_name"],
             )
 
-        @app.route("/favicon.ico", ["GET"])
+        @app.route("/favicon.ico", methods=["GET"])
         async def yobot_favicon():
             return await send_from_directory(static_folder, "small.ico")
 


### PR DESCRIPTION
Try to fix `TypeError: Scaffold.route() takes 2 positional arguments but 3 were given` error when running with Quart>=0.19 and Flask>=3.0
Close #106, close #108, close #110 