### PR TITLE
fix: 修复自动获取所有boss数据后，存在负数周目，无法保存的问题 feature:自动获取BOSS数据排除台服

### DIFF
--- a/src/client/public/static/admin/setting.js
+++ b/src/client/public/static/admin/setting.js
@@ -25,9 +25,9 @@ var vm = new Vue({
     },
     methods: {
         update: function (event) {
-            var flag = this.check_level_by_cycle()
+            var [flag, msg] = this.check_level_by_cycle()
             if (!flag) {
-                alert('阶段对应周目错误。\n不同阶段的周目范围不能重叠，且下阶段开始周目必须等于上阶段结束周目加一');
+                alert(msg);
                 return
             }
             this.setting.web_mode_hint = false;
@@ -38,7 +38,7 @@ var vm = new Vue({
                     csrf_token: csrf_token,
                 },
             ).then(function (res) {
-                if (res.data.code == 0) {
+                if (res.data.code === 0) {
                     alert('设置成功，重启机器人后生效');
                 } else {
                     alert('设置失败：' + res.data.message);
@@ -124,15 +124,21 @@ var vm = new Vue({
             this.setting.level_by_cycle[area].pop();
         },
         check_level_by_cycle: function () {
+            const regionMap = {cn: "国服", jp: "日服", tw: "台服"};
             for (const area in this.setting.level_by_cycle) {
-                var last_level_max = 0
+                var last_level_max = this.setting.level_by_cycle[area][0][0]-1;
+                var has_level_starting_with_1 = false;
                 for (const level_info of this.setting.level_by_cycle[area]) {
-                    if (level_info[0] != last_level_max + 1 || level_info[0] > level_info[1])
-                        return false
+                    if (level_info[0] !== last_level_max + 1 || level_info[0] > level_info[1])
+                        return [false,`${regionMap[area]}阶段对应周目错误。\n不同阶段的周目范围不能重叠，且下阶段开始周目必须等于上阶段结束周目加一`];
+                    if (level_info[0] === 1)
+                        has_level_starting_with_1 = true;
                     last_level_max = level_info[1]
                 }
+                if (!has_level_starting_with_1)
+                    return [false, `${regionMap[area]}阶段对应周目错误。\n至少要有一个阶段以1周目开始`];
             }
-            return true
+            return [true,'']
         }
     },
     delimiters: ['[[', ']]'],

--- a/src/client/public/template/admin/setting.html
+++ b/src/client/public/template/admin/setting.html
@@ -123,7 +123,7 @@
       <el-collapse v-model="activeNames" @change="bossSetting = !bossSetting">
         <el-collapse-item title="boss设置（点击展开）" name="1">
           <div :hidden="!bossSetting">
-            <el-button style="background-color: greenyellow;font-size: medium;" @click="auto_get_boss_data()">自动获取所有boss数据</el-button>
+            <el-button style="background-color: greenyellow;font-size: medium;" @click="auto_get_boss_data()">自动获取所有boss数据（除台服）</el-button>
             <div v-for="area_health, area in setting.boss" style="margin-bottom: 5%;">
               <h4 style="margin-bottom: -2%;">[[ {jp:"日服",tw:"台服",cn:"国服",eff:"得分系数"}[area] ]]</h4>
               <table>

--- a/src/client/ybplugins/settings.py
+++ b/src/client/ybplugins/settings.py
@@ -393,6 +393,8 @@ class Setting:
 
             boss_infos:dict = self.setting['boss']
             for server, _ in boss_infos.items():
+                if server == "tw":
+                    continue
                 real_url = url.format(server)
                 try:
                     async with aiohttp.ClientSession() as ses:


### PR DESCRIPTION
修复自动获取所有boss数据后，存在负数周目，无法保存的问题
另外由于[公主连接box](https://pcr.satroki.tech)已无法获取台服会战信息，还会错误被简中服信息替换，因此在自动获取所有boss数据中排除台服