### PR TITLE
Fix [CQ:at,qq=None]

### DIFF
--- a/src/client/ybplugins/clan_battle/components/web_operation.py
+++ b/src/client/ybplugins/clan_battle/components/web_operation.py
@@ -236,8 +236,10 @@ def register_routes(self, app: Quart):
 					is_continue = payload['is_continue']
 					behalf = payload['behalf']
 					boss_num = payload['boss_num']
-					if behalf == user_id: behalf = None
-					status = self.apply_for_challenge(is_continue, group_id, user_id, boss_num, behalf)
+					if behalf == user_id: 
+						status = self.apply_for_challenge(is_continue, group_id, user_id, boss_num)
+					else:
+						status = self.apply_for_challenge(is_continue, group_id, user_id, boss_num, behalf)
 				except ClanBattleError as e:
 					_logger.info('网页 失败 {} {} {}'.format(user_id, group_id, action))
 					return jsonify(


### PR DESCRIPTION
解决在会战管理面板点击申请出刀后，Bot 没有获取到已登录用户的 QQ 号的问题
#102 